### PR TITLE
Export merged QuantityValue as the public class

### DIFF
--- a/src/opensemantic/characteristics/quantitative/__init__.py
+++ b/src/opensemantic/characteristics/quantitative/__init__.py
@@ -16,7 +16,7 @@ from opensemantic.characteristics.quantitative._model import *  # noqa
 for _unwanted in ("Any", "Field"):  # noqa
     globals().pop(_unwanted, None)
 from opensemantic.characteristics.quantitative._collection import Unit  # noqa
-from opensemantic.characteristics.quantitative._static import (  # noqa
-    QuantityValue,
-    TabularData,
-)
+
+# QuantityValue is the merged generated class (Characteristic + _static mixin)
+# exported by the wildcard above; only TabularData is _static-only.
+from opensemantic.characteristics.quantitative._static import TabularData  # noqa

--- a/src/opensemantic/characteristics/quantitative/_static.py
+++ b/src/opensemantic/characteristics/quantitative/_static.py
@@ -391,14 +391,15 @@ class QuantityValue(OswBaseModel, metaclass=QuantityValueMetaclass):
                 )
 
         def class_logic(unit_class_):
-            if cls != QuantityValue:
+            if cls.__name__ != "QuantityValue":
                 # If the class is not the generic QuantityValue, it must be a subclass
-                #  of QuantityValue, so we can use it directly.
+                #  of QuantityValue, so we can use it directly. Match by name: the
+                #  public QuantityValue is the merged _model class, distinct from the
+                #  _static one referenced here.
                 quantity_class_ = cls
             elif unit_class_ == Unit:
-                # If the unit_class is the generic Unit, we can use the generic
-                #  QuantityValue class directly.
-                quantity_class_ = QuantityValue
+                # If the unit_class is the generic Unit, use the generic class as-is.
+                quantity_class_ = cls
             else:
                 # In any other case, we need to look up the quantity class in the
                 #  quantity_registry based on the unit_class.

--- a/src/opensemantic/characteristics/quantitative/v1/__init__.py
+++ b/src/opensemantic/characteristics/quantitative/v1/__init__.py
@@ -16,7 +16,7 @@ from opensemantic.characteristics.quantitative.v1._model import *  # noqa
 for _unwanted in ("Any", "Optional", "Field"):  # noqa
     globals().pop(_unwanted, None)
 from opensemantic.characteristics.quantitative.v1._collection import Unit  # noqa
-from opensemantic.characteristics.quantitative.v1._static import (  # noqa
-    QuantityValue,
-    TabularData,
-)
+
+# QuantityValue is the merged generated class (Characteristic + _static mixin)
+# exported by the wildcard above; only TabularData is _static-only.
+from opensemantic.characteristics.quantitative.v1._static import TabularData  # noqa

--- a/src/opensemantic/characteristics/quantitative/v1/_static.py
+++ b/src/opensemantic/characteristics/quantitative/v1/_static.py
@@ -424,14 +424,15 @@ class QuantityValue(OswBaseModel, metaclass=QuantityValueMetaclass):
                 )
 
         def class_logic(unit_class_):
-            if cls != QuantityValue:
+            if cls.__name__ != "QuantityValue":
                 # If the class is not the generic QuantityValue, it must be a subclass
-                #  of QuantityValue, so we can use it directly.
+                #  of QuantityValue, so we can use it directly. Match by name: the
+                #  public QuantityValue is the merged _model class, distinct from the
+                #  _static one referenced here.
                 quantity_class_ = cls
             elif unit_class_ == Unit:
-                # If the unit_class is the generic Unit, we can use the generic
-                #  QuantityValue class directly.
-                quantity_class_ = QuantityValue
+                # If the unit_class is the generic Unit, use the generic class as-is.
+                quantity_class_ = cls
             else:
                 # In any other case, we need to look up the quantity class in the
                 #  quantity_registry based on the unit_class.


### PR DESCRIPTION
The package `__init__` re-exported `QuantityValue` from `_static` (a pre-merge leftover), shadowing the merged `_model.QuantityValue` with the bare `OswBaseModel` mixin. As a result the public `QuantityValue` (and any downstream subclasses, e.g. Terravac's slope characteristics) were **not** `Characteristic` subclasses.

- Export the merged generated `QuantityValue` (which inherits the `_static` mixin's metaclass/behaviour and adds `Characteristic` + OO-LD); keep only `TabularData` from `_static`.
- `class_logic` now matches the generic class by name, since the public `QuantityValue` is a distinct class from the `_static` reference.

All 65 tests pass.